### PR TITLE
Improve requirement removal and candidate analysis button

### DIFF
--- a/app/Http/Controllers/ProjectRequirementController.php
+++ b/app/Http/Controllers/ProjectRequirementController.php
@@ -72,4 +72,44 @@ class ProjectRequirementController extends Controller
             ], 500);
         }
     }
+
+    /**
+     * Deactivate (remove) a project requirement.
+     */
+    public function destroy(Project $project, ProjectRequirement $requirement)
+    {
+        $this->authorize('update', $project);
+
+        if ($requirement->project_id !== $project->id) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Requirement not found for this project',
+            ], 404);
+        }
+
+        try {
+            $requirement->is_active = false;
+            $requirement->save();
+
+            Log::info('Project requirement removed via CV Analyzer', [
+                'project_id' => $project->id,
+                'requirement_id' => $requirement->id,
+            ]);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Requirement removed successfully',
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Failed to remove project requirement: ' . $e->getMessage(), [
+                'project_id' => $project->id,
+                'requirement_id' => $requirement->id,
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Failed to remove requirement: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
 }

--- a/resources/views/candidates/analyzer.blade.php
+++ b/resources/views/candidates/analyzer.blade.php
@@ -329,16 +329,7 @@
             // Remove requirement buttons
             const removeRequirementBtns = document.querySelectorAll('.remove-requirement-btn');
             removeRequirementBtns.forEach(btn => {
-                btn.addEventListener('click', function() {
-                    const requirementItem = this.closest('.requirement-item');
-                    const id = requirementItem.getAttribute('data-id');
-                    const name = requirementItem.querySelector('.font-medium').textContent.trim();
-                    
-                    if (confirm(`Are you sure you want to remove the requirement: ${name}?`)) {
-                        // Send chat message to remove requirement
-                        sendChatMessage(`Remove requirement: ${name}`);
-                    }
-                });
+                attachRemoveRequirementListener(btn);
             });
             
             // Save requirement button
@@ -461,12 +452,48 @@
                 
                 // Add event listener to the remove button
                 const removeBtn = requirementItem.querySelector('.remove-requirement-btn');
-                removeBtn.addEventListener('click', function() {
+                attachRemoveRequirementListener(removeBtn);
+            }
+
+            function attachRemoveRequirementListener(button) {
+                button.addEventListener('click', function() {
+                    const requirementItem = this.closest('.requirement-item');
+                    const id = requirementItem.getAttribute('data-id');
                     const name = requirementItem.querySelector('.font-medium').textContent.trim();
-                    
+
                     if (confirm(`Are you sure you want to remove the requirement: ${name}?`)) {
-                        // Send chat message to remove requirement
-                        sendChatMessage(`Remove requirement: ${name}`);
+                        fetch('{{ url('projects/'.$project->id.'/requirements') }}/' + id, {
+                            method: 'DELETE',
+                            headers: {
+                                'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                                'Accept': 'application/json',
+                            },
+                        })
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.success) {
+                                requirementItem.remove();
+
+                                const requirementsList = document.getElementById('requirements-list');
+                                if (requirementsList.children.length === 0) {
+                                    const emptyMessage = document.createElement('div');
+                                    emptyMessage.className = 'text-center py-4 text-gray-500';
+                                    emptyMessage.innerHTML = `
+                                        <p>No requirements defined yet.</p>
+                                        <p class="text-sm">Add requirements manually or use the chat interface.</p>
+                                    `;
+                                    requirementsList.appendChild(emptyMessage);
+                                }
+
+                                sendChatMessage(`Remove requirement ${name}`);
+                            } else {
+                                alert('Error removing requirement: ' + (data.message || 'Unknown error'));
+                            }
+                        })
+                        .catch(error => {
+                            console.error('Error:', error);
+                            alert('Failed to remove requirement. Please try again.');
+                        });
                     }
                 });
             }

--- a/resources/views/candidates/show.blade.php
+++ b/resources/views/candidates/show.blade.php
@@ -112,15 +112,22 @@
                                     <p class="font-medium">{{ $candidate->created_at->format('M d, Y') }}</p>
                                 </div>
                                 
-                                @if($candidate->last_analyzed_at)
-                                <div>
-                                    <p class="text-sm text-gray-500">Last Analyzed</p>
-                                    <p class="font-medium">{{ $candidate->last_analyzed_at->format('M d, Y H:i') }}</p>
-                                </div>
-                                @endif
-                            </div>
+                        @if($candidate->last_analyzed_at)
+                        <div>
+                            <p class="text-sm text-gray-500">Last Analyzed</p>
+                            <p class="font-medium">{{ $candidate->last_analyzed_at->format('M d, Y H:i') }}</p>
+                        </div>
+                        @endif
+
+                        <div class="pt-4">
+                            <form action="{{ route('candidates.analyze', $candidate) }}" method="POST" onsubmit="return confirm('Analyze this candidate?');">
+                                @csrf
+                                <x-primary-button>{{ __('Analyze Candidate') }}</x-primary-button>
+                            </form>
                         </div>
                     </div>
+                </div>
+            </div>
                     
                     <!-- Notes Card -->
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg mb-6">

--- a/routes/web.php
+++ b/routes/web.php
@@ -105,6 +105,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     
     // Project Requirements
     Route::post('/projects/{project}/requirements', [ProjectRequirementController::class, 'store'])->name('projects.requirements.store');
+    Route::delete('/projects/{project}/requirements/{requirement}', [ProjectRequirementController::class, 'destroy'])->name('projects.requirements.destroy');
     
     // Candidate Profiles
     Route::get('/profiles', [CandidateProfileController::class, 'projectSelection'])->name('profiles.project-selection');


### PR DESCRIPTION
## Summary
- support deleting requirements via API
- route & controller method for deletion
- update analyzer JS to remove items from DOM and database
- add "Analyze Candidate" button on candidate show page

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*